### PR TITLE
add email and URL filters

### DIFF
--- a/octis/preprocessing/preprocessing.py
+++ b/octis/preprocessing/preprocessing.py
@@ -38,6 +38,7 @@ SPACY_MODEL_MAPPING = {
 
 
 EMAIL_PATTERN = "\S*@\S*\s?"
+URL_PATTERN = "http\S+"
 
 
 class Preprocessing:
@@ -86,6 +87,8 @@ class Preprocessing:
         :type remove_numbers: bool
         :param remove_emails: if true, email addresses will be removed
         :type remove_emails: bool
+        :param remove_urls: if true, URLs will be removed
+        :type remove_urls: bool
         :param remove_stopwords_spacy: bool , if true use spacy to remove stopwords (default: true)
         :param lemmatize: if true, words will be lemmatized using a spacy model according to the language that has been
         set (default: true)
@@ -125,6 +128,7 @@ class Preprocessing:
         self.num_processes = num_processes
         self.remove_numbers = remove_numbers
         self.remove_emails = remove_emails
+        self.remove_urls = remove_urls
         self.save_original_indexes = save_original_indexes
         self.entities = entities
 
@@ -444,6 +448,9 @@ class Preprocessing:
 
             if self.remove_emails:
                 new_d = re.sub(EMAIL_PATTERN, "", new_d)
+
+            if self.remove_urls:
+                new_d = re.sub(URL_PATTERN, "", new_d)
                 
             if self.lowercase:
                 new_d = new_d.lower()

--- a/octis/preprocessing/preprocessing.py
+++ b/octis/preprocessing/preprocessing.py
@@ -53,6 +53,7 @@ class Preprocessing:
         punctuation: str = string.punctuation,
         remove_numbers: bool = True,
         remove_emails: bool = True,
+        remove_urls: bool = True,
         lemmatize: bool = True,
         stopword_list: str | list[str] = None,
         min_chars: int = 1,


### PR DESCRIPTION
**Email filter**
Solution taken [here](https://stackoverflow.com/questions/44027943/python-regex-to-remove-emails-from-string) which provide a testing bed [here](https://regex101.com/r/J0ohIf/1)

Example of results:
```
[IN]
import re
EMAIL_PATTERN = "\S*@\S*\s?"

new_d = """My email is user@mail.com
2134@mail.org is my email
<123@123.cn>
"""

print(new_d)
new_d = re.sub(EMAIL_PATTERN, "", new_d)
print(new_d)


[OUT]
My email is user@mail.com
2134@mail.org is my email
<123@123.cn>

My email is is my email
```

**URL filter**
Solution taken [here](https://stackoverflow.com/questions/11331982/how-to-remove-any-url-within-a-string-in-python)

Example of results:
```
[IN]
import re
URL_PATTERN = "http\S+"

new_d = """My website is at https://meet.google.com/wio-fehh-qrh?authuser=0
https://github.com/mila-aia/OCTIS/pull/5/files is my website
<https://www.snorkel.org/>
"""

print(new_d)
new_d = re.sub(URL_PATTERN, "", new_d)
print(new_d)

[OUT]
My website is at 
 is my website
<
```
